### PR TITLE
added support for glossaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ error-chain = "0.12"
 clap        = { version = "3.1", features = ["derive"] }
 serde       = { version = "1.0",  features = ["derive"] }
 reqwest     = { version = "0.11", features = ["blocking", "json"] }
+chrono      = { version = "0.4.22", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd  = "1.0"

--- a/src/bin/deepl/main.rs
+++ b/src/bin/deepl/main.rs
@@ -118,6 +118,7 @@ fn translate(deepl: &DeepL, t: &Translate) -> Result<()> {
         split_sentences: None,
         preserve_formatting: None,
         formality: None,
+        glossary_id: None
     };
     if t.preserve_formatting {
         t_opts.preserve_formatting = Some(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,9 @@
 //!
 //! The main API functions are documented in the [DeepL] struct.
 
+use chrono::{DateTime, Utc};
 use error_chain::*;
-use reqwest;
+use reqwest::{self, Method, blocking::Response};
 use serde::Deserialize;
 
 /// Information about API usage & limits for this account.
@@ -93,6 +94,41 @@ pub struct TranslationOptions {
     pub preserve_formatting: Option<bool>,
     /// Sets whether the translated text should lean towards formal or informal language.
     pub formality: Option<Formality>,
+    /// Specify the glossary to use for the translation.
+    pub glossary_id: Option<String>,
+}
+
+/// Format of glossary entries when creating a glossary.
+pub enum GlossaryEntriesFormat {
+    /// tab-separated values
+    Tsv,
+    /// comma-separated values
+    Csv,
+}
+
+/// Representation of a glossary.
+#[derive(Debug, Deserialize)]
+pub struct Glossary {
+    /// A unique ID assigned to a glossary.
+    pub glossary_id: String,
+    /// Name associated with the glossary.
+    pub name: String,
+    /// Indicates if the newly created glossary can already be used in translate requests. If the created glossary is not yet ready, you have to wait and check the ready status of the glossary before using it in a translate request.
+    pub ready: bool,
+    /// The language in which the source texts in the glossary are specified.
+    pub source_lang: String,
+    /// The language in which the target texts in the glossary are specified.
+    pub target_lang: String,
+    /// The creation time of the glossary.
+    pub creation_time: DateTime<Utc>,
+    /// The number of entries in the glossary.
+    pub entry_count: u64,
+}
+// Representation of a glossary listing response.
+#[derive(Debug, Deserialize)]
+pub struct GlossaryListing {
+    /// A list of glossaries.
+    pub glossaries: Vec<Glossary>,
 }
 
 /// Holds a list of strings to be translated.
@@ -126,6 +162,7 @@ struct TranslatedTextList {
 #[derive(Debug, Deserialize)]
 struct ServerErrorMessage {
     message: String,
+    detail: Option<String>
 }
 
 /// The main API entry point representing a DeepL developer account with an associated API key.
@@ -158,8 +195,9 @@ impl DeepL {
     /// Private method that performs the HTTP calls.
     fn http_request(
         &self,
+        method: Method,
         url: &str,
-        query: &Vec<(&str, std::string::String)>,
+        params: Option<&[(&str, std::string::String)]>,
     ) -> Result<reqwest::blocking::Response> {
 
         let url = match self.api_key.ends_with(":fx") {
@@ -167,12 +205,23 @@ impl DeepL {
             false => format!("https://api.deepl.com/v2{}", url),
         };
 
-        let mut payload = query.clone();
-        payload.push(("auth_key", self.api_key.clone()));
-
         let client = reqwest::blocking::Client::new();
+        let request = client.request(method.clone(), &url).header("Authorization", format!("DeepL-Auth-Key {}", self.api_key));
 
-        let res = match client.post(&url).query(&payload).send() {
+        let response = match params {
+            Some(params) => {
+                match method {
+                    Method::GET => request.query(params).send(),
+                    Method::PATCH | Method::POST | Method::PUT => {
+                        request.form(params).send()
+                    },
+                    _ => unreachable!("Only GET, PATCH, POST and PUT are supported with params."),
+                }
+            },
+            None => request.send(),
+        };
+
+        let res = match response {
             Ok(response) if response.status().is_success() => response,
             Ok(response) if response.status() == reqwest::StatusCode::UNAUTHORIZED => {
                 bail!(ErrorKind::AuthorizationError)
@@ -180,12 +229,15 @@ impl DeepL {
             Ok(response) if response.status() == reqwest::StatusCode::FORBIDDEN => {
                 bail!(ErrorKind::AuthorizationError)
             }
+            Ok(response) if response.status() == reqwest::StatusCode::NOT_FOUND => {
+                bail!(ErrorKind::NotFoundError)
+            }
             // DeepL sends back error messages in the response body.
             //   Try to fetch them to construct more helpful exceptions.
             Ok(response) => {
                 let status = response.status();
                 match response.json::<ServerErrorMessage>() {
-                    Ok(server_error) => bail!(ErrorKind::ServerError(server_error.message)),
+                    Ok(server_error) => bail!(ErrorKind::ServerError(format!("{}: {}", server_error.message, server_error.detail.unwrap_or_default()))),
                     _ => bail!(ErrorKind::ServerError(status.to_string())),
                 }
             }
@@ -201,7 +253,7 @@ impl DeepL {
     ///
     /// See also the [vendor documentation](https://www.deepl.com/docs-api/other-functions/monitoring-usage/).
     pub fn usage_information(&self) -> Result<UsageInformation> {
-        let res = self.http_request("/usage", &vec![])?;
+        let res = self.http_request(Method::POST, "/usage", None)?;
 
         match res.json::<UsageInformation>() {
             Ok(content) => return Ok(content),
@@ -227,7 +279,7 @@ impl DeepL {
 
     /// Private method to make the API calls for the language lists.
     fn languages(&self, language_type: &str) -> Result<LanguageList> {
-        let res = self.http_request("/languages", &vec![("type", language_type.to_string())])?;
+            let res = self.http_request(Method::POST, "/languages", Some(&[("type", language_type.to_string())]))?;
 
         match res.json::<LanguageList>() {
             Ok(content) => return Ok(content),
@@ -284,12 +336,74 @@ impl DeepL {
                     },
                 ));
             }
+            if let Some(glossary_id) = opt.glossary_id {
+                query.push(("glossary_id", glossary_id));
+            }
         }
 
-        let res = self.http_request("/translate", &query)?;
+        let res = self.http_request(Method::POST, "/translate", Some(&query))?;
 
         match res.json::<TranslatedTextList>() {
             Ok(content) => Ok(content.translations),
+            _ => bail!(ErrorKind::DeserializationError),
+        }
+    }
+
+    /// Create a glossary.
+    ///
+    /// Please take a look at the [vendor documentation](https://www.deepl.com/de/docs-api/glossaries/create-glossary/) for details.
+    pub fn create_glossary(
+        &self,
+        name: String,
+        source_lang: String,
+        target_lang: String,
+        entries: String,
+        entries_format: GlossaryEntriesFormat
+    ) -> Result<Glossary> {
+        let res = self.http_request(Method::POST, "/glossaries", Some(&[
+            ("name", name),
+            ("source_lang", source_lang),
+            ("target_lang", target_lang),
+            ("entries", entries),
+            ("entries_format", match entries_format {
+                GlossaryEntriesFormat::Tsv => "tsv".to_string(),
+                GlossaryEntriesFormat::Csv => "csv".to_string(),
+            })])
+        )?;
+
+        match res.json::<Glossary>() {
+            Ok(content) => Ok(content),
+            _ => bail!(ErrorKind::DeserializationError),
+        }
+    }
+
+    /// List all glossaries.
+    ///
+    /// Please take a look at the [vendor documentation](https://www.deepl.com/de/docs-api/glossaries/list-glossaries/) for details.
+    pub fn list_glossaries(&self) -> Result<GlossaryListing> {
+        let res = self.http_request(Method::GET, "/glossaries", None)?;
+
+        match res.json::<GlossaryListing>() {
+            Ok(content) => Ok(content),
+            _ => bail!(ErrorKind::DeserializationError),
+        }
+    }
+
+    /// Delete a glossary.
+    ///
+    /// Please take a look at the [vendor documentation](https://www.deepl.com/de/docs-api/glossaries/delete-glossary/) for details.
+    pub fn delete_glossary(&self, glossary_id: String) -> Result<Response> {
+        self.http_request(Method::DELETE, &format!("/glossaries/{}", glossary_id), None)
+    }
+
+    /// Retrieve Glossary Details.
+    ///
+    /// Please take a look at the [vendor documentation](https://www.deepl.com/de/docs-api/glossaries/get-glossary/) for details.
+    pub fn get_glossary(&self, glossary_id: String) -> Result<Glossary> {
+        let res = self.http_request(Method::GET, &format!("/glossaries/{}", glossary_id), None)?;
+
+        match res.json::<Glossary>() {
+            Ok(content) => Ok(content),
             _ => bail!(ErrorKind::DeserializationError),
         }
     }
@@ -324,6 +438,11 @@ error_chain! {
             description("An error occurred while deserializing the response data.")
             display("An error occurred while deserializing the response data.")
         }
+        /// Resource was not found
+        NotFoundError {
+            description("The requested resource was not found.")
+            display("The requested resource was not found.")
+        }
     }
 
     skip_msg_variant
@@ -333,31 +452,32 @@ error_chain! {
 mod tests {
     use super::*;
 
+    fn create_deepl() -> DeepL {
+        let key = std::env::var("DEEPL_API_KEY").unwrap();
+        DeepL::new(key)
+    }
+
     #[test]
     fn usage_information() {
-        let key = std::env::var("DEEPL_API_KEY").unwrap();
-        let usage_information = DeepL::new(key).usage_information().unwrap();
+        let usage_information = create_deepl().usage_information().unwrap();
         assert!(usage_information.character_limit > 0);
     }
 
     #[test]
     fn source_languages() {
-        let key = std::env::var("DEEPL_API_KEY").unwrap();
-        let source_languages = DeepL::new(key).source_languages().unwrap();
+        let source_languages = create_deepl().source_languages().unwrap();
         assert_eq!(source_languages.last().unwrap().name, "Chinese");
     }
 
     #[test]
     fn target_languages() {
-        let key = std::env::var("DEEPL_API_KEY").unwrap();
-        let target_languages = DeepL::new(key).target_languages().unwrap();
+        let target_languages = create_deepl().target_languages().unwrap();
         assert_eq!(target_languages.last().unwrap().name, "Chinese");
     }
 
     #[test]
     fn translate() {
-        let key = std::env::var("DEEPL_API_KEY").unwrap();
-        let deepl = DeepL::new(key);
+        let deepl = create_deepl();
         let tests = vec![
             (
                 None,
@@ -375,6 +495,7 @@ mod tests {
                 Some(TranslationOptions {
                     split_sentences: None,
                     preserve_formatting: Some(true),
+                    glossary_id: None,
                     formality: None,
                 }),
                 TranslatableTextList {
@@ -391,6 +512,7 @@ mod tests {
                 Some(TranslationOptions {
                     split_sentences: Some(SplitSentences::None),
                     preserve_formatting: None,
+                    glossary_id: None,
                     formality: None,
                 }),
                 TranslatableTextList {
@@ -407,6 +529,7 @@ mod tests {
                 Some(TranslationOptions {
                     split_sentences: None,
                     preserve_formatting: None,
+                    glossary_id: None,
                     formality: Some(Formality::More),
                 }),
                 TranslatableTextList {
@@ -423,6 +546,7 @@ mod tests {
                 Some(TranslationOptions {
                     split_sentences: None,
                     preserve_formatting: None,
+                    glossary_id: None,
                     formality: Some(Formality::Less),
                 }),
                 TranslatableTextList {
@@ -444,25 +568,23 @@ mod tests {
     #[test]
     #[should_panic(expected = "Error(ServerError(\"Parameter 'text' not specified.")]
     fn translate_empty() {
-        let key = std::env::var("DEEPL_API_KEY").unwrap();
         let texts = TranslatableTextList {
             source_language: Some("DE".to_string()),
             target_language: "EN-US".to_string(),
             texts: vec![],
         };
-        DeepL::new(key).translate(None, texts).unwrap();
+        create_deepl().translate(None, texts).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "Error(ServerError(\"Value for 'target_lang' not supported.")]
     fn translate_wrong_language() {
-        let key = std::env::var("DEEPL_API_KEY").unwrap();
         let texts = TranslatableTextList {
             source_language: None,
             target_language: "NONEXISTING".to_string(),
             texts: vec!["ja".to_string()],
         };
-        DeepL::new(key).translate(None, texts).unwrap();
+        create_deepl().translate(None, texts).unwrap();
     }
 
     #[test]
@@ -475,5 +597,52 @@ mod tests {
             texts: vec!["ja".to_string()],
         };
         DeepL::new(key).translate(None, texts).unwrap();
+    }
+
+    #[test]
+    fn glossaries() {
+        let deepl = create_deepl();
+        let glossary_name = "test_glossary".to_string();
+
+        let mut glossary = deepl.create_glossary(
+            glossary_name.clone(),
+            "en".to_string(),
+            "de".to_string(),
+            "Action,Handlung".to_string(),
+            GlossaryEntriesFormat::Csv
+        ).unwrap();
+
+        assert_eq!(glossary.name, glossary_name);
+        assert_eq!(glossary.entry_count, 1);
+
+        glossary = deepl.get_glossary(glossary.glossary_id).unwrap();
+        assert_eq!(glossary.name, glossary_name);
+        assert_eq!(glossary.entry_count, 1);
+
+        let mut glossaries = deepl.list_glossaries().unwrap().glossaries;
+        glossaries.retain(|glossary| glossary.name == glossary_name);
+        let glossary = glossaries.pop().unwrap();
+        assert_eq!(glossary.name, glossary_name);
+        assert_eq!(glossary.entry_count, 1);
+
+        assert_eq!(deepl.translate(
+            Some(
+                TranslationOptions {
+                    split_sentences: None,
+                    preserve_formatting: None,
+                    glossary_id: Some(glossary.glossary_id.clone()),
+                    formality: None,
+                }
+            ),
+            TranslatableTextList {
+                source_language: Some("en".to_string()),
+                target_language: "de".to_string(),
+                texts: vec!["Action".to_string()],
+            }
+        ).unwrap().pop().unwrap().text, "Handlung");
+
+        deepl.delete_glossary(glossary.glossary_id.clone()).unwrap();
+        let glossary_response = deepl.get_glossary(glossary.glossary_id);
+        assert_eq!(glossary_response.unwrap_err().to_string(), crate::ErrorKind::NotFoundError.to_string());
     }
 }


### PR DESCRIPTION
 - Added support for glossaries
 - Made request method explicit (was POST only, needed other methods for glossary support)
 - Made request body optional (needed for glossary support)
 - Moved API key to HTTP header
 - Added optional `detail` to ServerErrorMessage
 - Added NotFoundError (needed for glossary test)