### PR TITLE
feat: implement `Clone` for `TranslationOptions`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub struct LanguageInformation {
 }
 
 /// Translation option that controls the splitting of sentences before the translation.
+#[derive(Clone)]
 pub enum SplitSentences {
     /// Don't split sentences.
     None,
@@ -77,6 +78,7 @@ pub enum SplitSentences {
 }
 
 /// Translation option that controls the desired translation formality.
+#[derive(Clone)]
 pub enum Formality {
     /// Default formality.
     Default,
@@ -87,6 +89,7 @@ pub enum Formality {
 }
 
 /// Custom [flags for the translation request](https://www.deepl.com/docs-api/translating-text/request/).
+#[derive(Clone)]
 pub struct TranslationOptions {
     /// Sets whether the translation engine should first split the input into sentences. This is enabled by default.
     pub split_sentences: Option<SplitSentences>,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -71,7 +71,7 @@ fn test_translate() {
         .code(2)
         .stdout(predicate::eq(""))
         .stderr(predicate::str::contains(
-            "error: The following required arguments were not provided:",
+            "error: the following required arguments were not provided:",
         ));
 
     // STDIN/STDOUT


### PR DESCRIPTION
First of all, thanks for making the crate open!

---

Since the struct does not implement the trait, it's difficult to reuse the same options across multiple requests.

The another way might include to provided a custom `copy` or a `new` method that takes a reference to the original struct, and creates a new with the same data. But since the struct (1) does not contain any reference, (2) does not contain fields which is hard or impossible to clone such as I/O resources, and (3) is a fairly small so that the cost of clone is negligible.

Please let me know your thoughts. Thanks!